### PR TITLE
Fix getCurrentPosition call for geolocator 12.x API

### DIFF
--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -53,7 +53,7 @@ class _MapScreenState extends State<MapScreen> {
   Future<void> _moveToCurrentLocation() async {
     try {
       final position = await Geolocator.getCurrentPosition(
-        locationSettings: const LocationSettings(accuracy: LocationAccuracy.high),
+        desiredAccuracy: LocationAccuracy.high,
       );
       _mapController?.animateCamera(
         CameraUpdate.newLatLngZoom(


### PR DESCRIPTION
locationSettings is not a valid parameter for getCurrentPosition; use desiredAccuracy directly instead.

https://claude.ai/code/session_01PDCaeWBXCJdsf8UqBRzEoa