### PR TITLE
Bump Kotlin to 2.3.10 and Java target to 11

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -22,12 +22,12 @@ android {
 
     compileOptions {
         coreLibraryDesugaringEnabled true
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 
     sourceSets {
@@ -58,6 +58,6 @@ flutter {
 
 dependencies {
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.4"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:2.1.0"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:2.3.10"
     implementation "androidx.multidex:multidex:2.0.1"
 }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.9.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.3.10" apply false
     id "com.google.gms.google-services" version "4.4.0" apply false
 }
 


### PR DESCRIPTION
Kotlin stdlib 2.3.10 is pulled transitively by google_maps_flutter_android; KGP must match. Java 8 target is obsolete in newer toolchains.

https://claude.ai/code/session_01PDCaeWBXCJdsf8UqBRzEoa