### PR TITLE
Fix MainActivity: use startActivityForResult instead of registerForAc…

### DIFF
--- a/android/app/src/main/kotlin/com/locatemeup/locatemeup/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/locatemeup/locatemeup/MainActivity.kt
@@ -6,9 +6,6 @@ import android.media.MediaPlayer
 import android.media.RingtoneManager
 import android.net.Uri
 import android.os.Build
-import android.os.Bundle
-import androidx.activity.result.ActivityResultLauncher
-import androidx.activity.result.contract.ActivityResultContracts
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
@@ -16,38 +13,9 @@ import io.flutter.plugin.common.MethodChannel
 class MainActivity : FlutterActivity() {
 
     private val CHANNEL = "com.locatemeup/ringtone"
+    private val RINGTONE_REQUEST = 9001
     private var mediaPlayer: MediaPlayer? = null
     private var pendingResult: MethodChannel.Result? = null
-    private lateinit var ringtoneLauncher: ActivityResultLauncher<Intent>
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        ringtoneLauncher = registerForActivityResult(
-            ActivityResultContracts.StartActivityForResult()
-        ) { result ->
-            val pr = pendingResult
-            pendingResult = null
-            if (result.resultCode == Activity.RESULT_OK) {
-                val uri: Uri? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                    result.data?.getParcelableExtra(
-                        RingtoneManager.EXTRA_RINGTONE_PICKED_URI, Uri::class.java
-                    )
-                } else {
-                    @Suppress("DEPRECATION")
-                    result.data?.getParcelableExtra(RingtoneManager.EXTRA_RINGTONE_PICKED_URI)
-                }
-                if (uri != null) {
-                    val title = RingtoneManager.getRingtone(applicationContext, uri)
-                        ?.getTitle(applicationContext) ?: "Ringtone"
-                    pr?.success(mapOf("uri" to uri.toString(), "title" to title))
-                } else {
-                    pr?.success(null)
-                }
-            } else {
-                pr?.success(null)
-            }
-        }
-    }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
@@ -69,7 +37,8 @@ class MainActivity : FlutterActivity() {
                                 )
                             }
                         }
-                        ringtoneLauncher.launch(intent)
+                        @Suppress("DEPRECATION")
+                        startActivityForResult(intent, RINGTONE_REQUEST)
                     }
 
                     "playRingtone" -> {
@@ -100,6 +69,31 @@ class MainActivity : FlutterActivity() {
                     else -> result.notImplemented()
                 }
             }
+    }
+
+    @Suppress("DEPRECATION")
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode != RINGTONE_REQUEST) return
+        val pr = pendingResult
+        pendingResult = null
+        if (resultCode == Activity.RESULT_OK) {
+            val uri: Uri? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                data?.getParcelableExtra(RingtoneManager.EXTRA_RINGTONE_PICKED_URI, Uri::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                data?.getParcelableExtra(RingtoneManager.EXTRA_RINGTONE_PICKED_URI)
+            }
+            if (uri != null) {
+                val title = RingtoneManager.getRingtone(applicationContext, uri)
+                    ?.getTitle(applicationContext) ?: "Ringtone"
+                pr?.success(mapOf("uri" to uri.toString(), "title" to title))
+            } else {
+                pr?.success(null)
+            }
+        } else {
+            pr?.success(null)
+        }
     }
 
     private fun releasePlayer() {


### PR DESCRIPTION
…tivityResult

androidx.activity artifact is not on the classpath so registerForActivityResult was an unresolved reference. The deprecated startActivityForResult/onActivityResult pair works without extra imports.

https://claude.ai/code/session_01PDCaeWBXCJdsf8UqBRzEoa