### PR TITLE
Fix splash screen: replace broken bitmap layer-list with gradient shape

### DIFF
--- a/android/app/src/main/res/drawable/splash_background.xml
+++ b/android/app/src/main/res/drawable/splash_background.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@color/splash_background" />
-    <item>
-        <bitmap
-            android:src="@drawable/ic_launcher_foreground"
-            android:gravity="center"
-            android:tint="@android:color/white" />
-    </item>
-</layer-list>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <gradient
+        android:startColor="#1565C0"
+        android:endColor="#42A5F5"
+        android:angle="135"
+        android:type="linear" />
+</shape>


### PR DESCRIPTION
bitmap elements can't reference vector drawables — they silently fail and the theme's black background shows through. Using a gradient shape drawable directly as windowBackground works on all API levels.

https://claude.ai/code/session_01PDCaeWBXCJdsf8UqBRzEoa