### PR TITLE
Background location via foreground service; redesign alarm screen

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,6 +19,10 @@
     <!-- Receive boot to restart background location if needed -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
+    <!-- Foreground service for continuous background location -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+
     <application
         android:label="LocateMeUp"
         android:name="${applicationName}"
@@ -68,5 +72,10 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+
+        <service
+            android:name=".LocationForegroundService"
+            android:foregroundServiceType="location"
+            android:exported="false" />
     </application>
 </manifest>

--- a/android/app/src/main/kotlin/com/locatemeup/locatemeup/LocationForegroundService.kt
+++ b/android/app/src/main/kotlin/com/locatemeup/locatemeup/LocationForegroundService.kt
@@ -1,0 +1,71 @@
+package com.locatemeup.locatemeup
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+
+class LocationForegroundService : Service() {
+
+    companion object {
+        private const val NOTIFICATION_ID = 2001
+        private const val CHANNEL_ID = "location_service_channel"
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        createChannel()
+        startForeground(NOTIFICATION_ID, buildNotification())
+        return START_STICKY
+    }
+
+    private fun createChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                "Location Monitoring",
+                NotificationManager.IMPORTANCE_LOW
+            ).apply {
+                description = "Active while location alarms are enabled"
+                setShowBadge(false)
+            }
+            (getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager)
+                .createNotificationChannel(channel)
+        }
+    }
+
+    private fun buildNotification(): Notification {
+        val launch = packageManager.getLaunchIntentForPackage(packageName)
+            ?.apply { flags = Intent.FLAG_ACTIVITY_SINGLE_TOP }
+        val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        else PendingIntent.FLAG_UPDATE_CURRENT
+        val pi = PendingIntent.getActivity(this, 0, launch, flags)
+
+        val builder = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Notification.Builder(this, CHANNEL_ID)
+        } else {
+            @Suppress("DEPRECATION")
+            Notification.Builder(this)
+        }
+        return builder
+            .setContentTitle("LocateMeUp")
+            .setContentText("Monitoring location for alarms")
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentIntent(pi)
+            .setOngoing(true)
+            .build()
+    }
+
+    override fun onDestroy() {
+        @Suppress("DEPRECATION")
+        stopForeground(true)
+        super.onDestroy()
+    }
+}

--- a/android/app/src/main/kotlin/com/locatemeup/locatemeup/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/locatemeup/locatemeup/MainActivity.kt
@@ -12,7 +12,8 @@ import io.flutter.plugin.common.MethodChannel
 
 class MainActivity : FlutterActivity() {
 
-    private val CHANNEL = "com.locatemeup/ringtone"
+    private val RINGTONE_CHANNEL = "com.locatemeup/ringtone"
+    private val LOCATION_CHANNEL = "com.locatemeup/location"
     private val RINGTONE_REQUEST = 9001
     private var mediaPlayer: MediaPlayer? = null
     private var pendingResult: MethodChannel.Result? = null
@@ -20,7 +21,7 @@ class MainActivity : FlutterActivity() {
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
 
-        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL)
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, RINGTONE_CHANNEL)
             .setMethodCallHandler { call, result ->
                 when (call.method) {
                     "pickRingtone" -> {
@@ -40,7 +41,6 @@ class MainActivity : FlutterActivity() {
                         @Suppress("DEPRECATION")
                         startActivityForResult(intent, RINGTONE_REQUEST)
                     }
-
                     "playRingtone" -> {
                         releasePlayer()
                         try {
@@ -60,12 +60,30 @@ class MainActivity : FlutterActivity() {
                             result.error("PLAY_ERROR", e.message, null)
                         }
                     }
-
                     "stopRingtone" -> {
                         releasePlayer()
                         result.success(null)
                     }
+                    else -> result.notImplemented()
+                }
+            }
 
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, LOCATION_CHANNEL)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "startService" -> {
+                        val intent = Intent(this, LocationForegroundService::class.java)
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                            startForegroundService(intent)
+                        } else {
+                            startService(intent)
+                        }
+                        result.success(null)
+                    }
+                    "stopService" -> {
+                        stopService(Intent(this, LocationForegroundService::class.java))
+                        result.success(null)
+                    }
                     else -> result.notImplemented()
                 }
             }

--- a/lib/screens/alarms_screen.dart
+++ b/lib/screens/alarms_screen.dart
@@ -69,7 +69,7 @@ class _AlarmsScreenState extends State<AlarmsScreen> with WidgetsBindingObserver
     showDialog<void>(
       context: context,
       builder: (ctx) => AlertDialog(
-        title: const Text('Cannot LocateYouUp'),
+        title: const Text('Location required'),
         content: const Text('Please enable Location Services to use alarms.'),
         actions: [
           TextButton(
@@ -114,27 +114,50 @@ class _AlarmsScreenState extends State<AlarmsScreen> with WidgetsBindingObserver
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final activeCount = _service.activeAlarmCount;
+
     return Scaffold(
+      backgroundColor: theme.colorScheme.surface,
       appBar: AppBar(
-        title: const Text('My Alarms'),
+        backgroundColor: theme.colorScheme.surface,
+        elevation: 0,
+        scrolledUnderElevation: 1,
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Alarms',
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 24),
+            ),
+            if (_service.alarms.isNotEmpty)
+              Text(
+                activeCount == 0
+                    ? 'All alarms off'
+                    : '$activeCount alarm${activeCount == 1 ? '' : 's'} active',
+                style: TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.normal,
+                  color: activeCount > 0
+                      ? theme.colorScheme.primary
+                      : theme.colorScheme.onSurface.withOpacity(0.5),
+                ),
+              ),
+          ],
+        ),
         actions: [
           if (Platform.isAndroid)
             IconButton(
-              icon: const Icon(Icons.music_note),
+              icon: const Icon(Icons.music_note_outlined),
               tooltip: 'Select ringtone',
               onPressed: _pickRingtone,
             ),
-          IconButton(
-            icon: const Icon(Icons.add_location_alt),
-            tooltip: 'Add alarm',
-            onPressed: _openMapScreen,
-          ),
         ],
       ),
       body: Column(
         children: [
-          if (_service.isFiring) _buildStopAlarmBanner(),
-          Expanded(child: _buildAlarmList()),
+          if (_service.isFiring) _buildStopAlarmBanner(theme),
+          Expanded(child: _buildAlarmList(theme)),
           if (_bannerAdLoaded && _bannerAd != null)
             SizedBox(
               height: _bannerAd!.size.height.toDouble(),
@@ -142,20 +165,25 @@ class _AlarmsScreenState extends State<AlarmsScreen> with WidgetsBindingObserver
             ),
         ],
       ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: _openMapScreen,
+        icon: const Icon(Icons.add_location_alt_outlined),
+        label: const Text('Add alarm'),
+      ),
     );
   }
 
-  Widget _buildStopAlarmBanner() {
+  Widget _buildStopAlarmBanner(ThemeData theme) {
     return Material(
-      color: Colors.red,
+      color: Colors.red.shade600,
       child: InkWell(
         onTap: () => _service.stopAlarm(),
         child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 20),
+          padding: const EdgeInsets.symmetric(vertical: 14, horizontal: 20),
           child: Row(
             children: [
-              const Icon(Icons.alarm_off, color: Colors.white, size: 28),
-              const SizedBox(width: 16),
+              const Icon(Icons.alarm_off, color: Colors.white, size: 26),
+              const SizedBox(width: 14),
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -165,7 +193,8 @@ class _AlarmsScreenState extends State<AlarmsScreen> with WidgetsBindingObserver
                       style: TextStyle(
                         color: Colors.white,
                         fontWeight: FontWeight.bold,
-                        fontSize: 18,
+                        fontSize: 16,
+                        letterSpacing: 0.5,
                       ),
                     ),
                     if (_service.firingAlarmTitle != null)
@@ -176,7 +205,21 @@ class _AlarmsScreenState extends State<AlarmsScreen> with WidgetsBindingObserver
                   ],
                 ),
               ),
-              const Icon(Icons.touch_app, color: Colors.white70),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(20),
+                ),
+                child: Text(
+                  'Stop',
+                  style: TextStyle(
+                    color: Colors.red.shade600,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 14,
+                  ),
+                ),
+              ),
             ],
           ),
         ),
@@ -184,29 +227,45 @@ class _AlarmsScreenState extends State<AlarmsScreen> with WidgetsBindingObserver
     );
   }
 
-  Widget _buildAlarmList() {
+  Widget _buildAlarmList(ThemeData theme) {
     if (_service.alarms.isEmpty) {
-      return const Center(
-        child: Padding(
-          padding: EdgeInsets.all(32),
-          child: Text(
-            'No alarms yet.\nTap + to add a location alarm.',
-            textAlign: TextAlign.center,
-            style: TextStyle(color: Colors.grey, fontSize: 16),
-          ),
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.add_location_alt_outlined,
+              size: 72,
+              color: theme.colorScheme.primary.withOpacity(0.3),
+            ),
+            const SizedBox(height: 20),
+            Text(
+              'No alarms yet',
+              style: theme.textTheme.titleLarge?.copyWith(
+                color: theme.colorScheme.onSurface.withOpacity(0.5),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Tap "Add alarm" to set a location alarm',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurface.withOpacity(0.4),
+              ),
+            ),
+            const SizedBox(height: 80),
+          ],
         ),
       );
     }
 
-    return ListView.separated(
+    return ListView.builder(
+      padding: const EdgeInsets.only(top: 8, bottom: 96),
       itemCount: _service.alarms.length,
-      separatorBuilder: (_, __) => const Divider(height: 1),
       itemBuilder: (context, index) {
         final alarm = _service.alarms[index];
         final pos = _service.currentPosition;
-        final distanceMeters = pos != null
-            ? alarm.distanceMeters(pos.latitude, pos.longitude)
-            : null;
+        final distanceMeters =
+            pos != null ? alarm.distanceMeters(pos.latitude, pos.longitude) : null;
 
         return AlarmTile(
           alarm: alarm,

--- a/lib/services/alarm_service.dart
+++ b/lib/services/alarm_service.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:geolocator/geolocator.dart';
 
 import '../models/alarm.dart';
@@ -9,6 +11,8 @@ import 'ringtone_service.dart';
 import 'storage_service.dart';
 
 class AlarmService extends ChangeNotifier {
+  static const _locationChannel = MethodChannel('com.locatemeup/location');
+
   final StorageService _storage = StorageService();
   final RingtoneService ringtoneService = RingtoneService();
 
@@ -86,9 +90,25 @@ class AlarmService extends ChangeNotifier {
   void _updateLocationMonitoring() {
     if (activeAlarmCount > 0 && isLocationAuthorized) {
       _startLocationMonitoring();
+      _startForegroundService();
     } else {
       _stopLocationMonitoring();
+      _stopForegroundService();
     }
+  }
+
+  Future<void> _startForegroundService() async {
+    if (!Platform.isAndroid) return;
+    try {
+      await _locationChannel.invokeMethod<void>('startService');
+    } catch (_) {}
+  }
+
+  Future<void> _stopForegroundService() async {
+    if (!Platform.isAndroid) return;
+    try {
+      await _locationChannel.invokeMethod<void>('stopService');
+    } catch (_) {}
   }
 
   void _startLocationMonitoring() {

--- a/lib/widgets/alarm_tile.dart
+++ b/lib/widgets/alarm_tile.dart
@@ -18,60 +18,107 @@ class AlarmTile extends StatelessWidget {
     required this.onDelete,
   });
 
-  /// Formats metres as km with Swiss-style apostrophe thousands separator,
-  /// matching the original iOS number formatter behaviour.
   String _formatDistance(double metres) {
+    if (metres < 1000) return '${metres.round()} m';
     final km = metres / 1000;
-    final formatted = km.toStringAsFixed(2);
-    final parts = formatted.split('.');
-    final intPart = parts[0];
-    final fracPart = parts[1];
-    final buf = StringBuffer();
-    for (int i = 0; i < intPart.length; i++) {
-      if (i > 0 && (intPart.length - i) % 3 == 0) buf.write("'");
-      buf.write(intPart[i]);
-    }
-    return "${buf.toString()}.$fracPart km";
+    return km < 10 ? '${km.toStringAsFixed(1)} km' : '${km.round()} km';
   }
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final active = alarm.isOn && isLocationEnabled;
+    final primary = theme.colorScheme.primary;
+    final onSurface = theme.colorScheme.onSurface;
+
     return Dismissible(
       key: Key(alarm.id),
       direction: DismissDirection.endToStart,
       background: Container(
-        color: Colors.red,
         alignment: Alignment.centerRight,
-        padding: const EdgeInsets.only(right: 16),
-        child: const Icon(Icons.delete, color: Colors.white),
+        padding: const EdgeInsets.only(right: 28),
+        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+        decoration: BoxDecoration(
+          color: Colors.red.shade400,
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: const Icon(Icons.delete_outline, color: Colors.white, size: 26),
       ),
       onDismissed: (_) => onDelete(),
-      child: ListTile(
-        title: Text(alarm.title, style: const TextStyle(fontWeight: FontWeight.bold)),
-        subtitle: Text(
-          alarm.subtitle,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
+      child: Card(
+        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+        elevation: active ? 2 : 0,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(20),
+          side: BorderSide(
+            color: active
+                ? primary.withOpacity(0.3)
+                : theme.colorScheme.outlineVariant.withOpacity(0.5),
+          ),
         ),
-        trailing: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            if (distanceMeters != null)
-              Padding(
-                padding: const EdgeInsets.only(right: 8),
-                child: Text(
-                  _formatDistance(distanceMeters!),
-                  style: Theme.of(context)
-                      .textTheme
-                      .bodySmall
-                      ?.copyWith(color: Colors.grey),
+        color: active
+            ? Color.alphaBlend(primary.withOpacity(0.06), theme.colorScheme.surface)
+            : theme.colorScheme.surfaceContainerHighest.withOpacity(0.4),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(20, 18, 8, 18),
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      alarm.title,
+                      style: theme.textTheme.headlineSmall?.copyWith(
+                        fontSize: 22,
+                        fontWeight: active ? FontWeight.w600 : FontWeight.w400,
+                        color: active ? onSurface : onSurface.withOpacity(0.4),
+                      ),
+                    ),
+                    if (alarm.subtitle.isNotEmpty) ...[
+                      const SizedBox(height: 4),
+                      Text(
+                        alarm.subtitle,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: active
+                              ? onSurface.withOpacity(0.6)
+                              : onSurface.withOpacity(0.3),
+                        ),
+                      ),
+                    ],
+                    if (distanceMeters != null) ...[
+                      const SizedBox(height: 10),
+                      Row(
+                        children: [
+                          Icon(
+                            Icons.near_me_outlined,
+                            size: 13,
+                            color: active ? primary : onSurface.withOpacity(0.3),
+                          ),
+                          const SizedBox(width: 4),
+                          Text(
+                            _formatDistance(distanceMeters!),
+                            style: TextStyle(
+                              fontSize: 13,
+                              fontWeight: FontWeight.w500,
+                              color: active ? primary : onSurface.withOpacity(0.3),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ],
                 ),
               ),
-            Switch(
-              value: alarm.isOn && isLocationEnabled,
-              onChanged: isLocationEnabled ? onToggle : null,
-            ),
-          ],
+              Switch(
+                value: active,
+                onChanged: isLocationEnabled ? onToggle : null,
+                activeColor: primary,
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
Background location:
- LocationForegroundService.kt: sticky foreground service with low-priority persistent notification keeps the process alive on Android
- MainActivity: new com.locatemeup/location channel to start/stop the service
- AndroidManifest: FOREGROUND_SERVICE + FOREGROUND_SERVICE_LOCATION permissions, service declared with foregroundServiceType="location"
- AlarmService: starts/stops the foreground service whenever active alarm count changes

Alarm screen redesign:
- AlarmTile: rounded cards (r=20), large location name, muted inactive state, coloured distance badge, swipe-delete with matching rounded red background
- AlarmsScreen: bold title with active-count subtitle, FAB replaces AppBar add button, improved empty state with icon, polished stop-alarm banner with white pill button

https://claude.ai/code/session_01PDCaeWBXCJdsf8UqBRzEoa