### PR TITLE
Bring app to foreground when alarm fires in background

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -23,6 +23,9 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
 
+    <!-- Bring app to foreground when alarm fires (full-screen intent) -->
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+
     <application
         android:label="LocateMeUp"
         android:name="${applicationName}"

--- a/android/app/src/main/kotlin/com/locatemeup/locatemeup/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/locatemeup/locatemeup/MainActivity.kt
@@ -84,6 +84,13 @@ class MainActivity : FlutterActivity() {
                         stopService(Intent(this, LocationForegroundService::class.java))
                         result.success(null)
                     }
+                    "bringToForeground" -> {
+                        val intent = Intent(this, MainActivity::class.java).apply {
+                            addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+                        }
+                        startActivity(intent)
+                        result.success(null)
+                    }
                     else -> result.notImplemented()
                 }
             }

--- a/lib/services/alarm_service.dart
+++ b/lib/services/alarm_service.dart
@@ -111,6 +111,13 @@ class AlarmService extends ChangeNotifier {
     } catch (_) {}
   }
 
+  Future<void> _bringToForeground() async {
+    if (!Platform.isAndroid) return;
+    try {
+      await _locationChannel.invokeMethod<void>('bringToForeground');
+    } catch (_) {}
+  }
+
   void _startLocationMonitoring() {
     if (_locationSubscription != null) return;
     const settings = LocationSettings(
@@ -146,6 +153,7 @@ class AlarmService extends ChangeNotifier {
           locationTitle: alarm.title,
         );
         ringtoneService.play();
+        _bringToForeground();
       }
     }
     if (changed) {

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -51,6 +51,8 @@ class NotificationService {
       playSound: false,
       ongoing: true,
       autoCancel: false,
+      fullScreenIntent: true,
+      category: AndroidNotificationCategory.alarm,
       actions: [
         AndroidNotificationAction('stop_alarm', 'Stop'),
       ],


### PR DESCRIPTION
- USE_FULL_SCREEN_INTENT permission in manifest
- Alarm notification uses fullScreenIntent=true + category=alarm: wakes the screen and launches the activity when device is locked/idle
- bringToForeground channel method in MainActivity uses FLAG_ACTIVITY_REORDER_TO_FRONT to move the task forward when the screen is already on and the app is backgrounded
- AlarmService calls _bringToForeground() alongside ringtone play

https://claude.ai/code/session_01PDCaeWBXCJdsf8UqBRzEoa