### PR TITLE
Configure release signing for Google Play

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Flutter / Dart
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+build/
+*.iml
+
+# Secrets
+upload-keystore.jks
+*.keystore

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -1,0 +1,4 @@
+# Signing secrets — never commit these
+key.properties
+*.jks
+*.keystore

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -15,6 +15,14 @@ if (localPropertiesFile.exists()) {
 def flutterVersionCode = localProperties.getProperty("flutter.versionCode") ?: "1"
 def flutterVersionName = localProperties.getProperty("flutter.versionName") ?: "1.0"
 
+def keyProperties = new Properties()
+def keyPropertiesFile = rootProject.file("key.properties")
+if (keyPropertiesFile.exists()) {
+    keyPropertiesFile.withReader("UTF-8") { reader ->
+        keyProperties.load(reader)
+    }
+}
+
 android {
     namespace "com.locatemeup.locatemeup"
     compileSdk 36
@@ -34,6 +42,15 @@ android {
         main.java.srcDirs += "src/main/kotlin"
     }
 
+    signingConfigs {
+        release {
+            keyAlias keyProperties["keyAlias"]
+            keyPassword keyProperties["keyPassword"]
+            storeFile keyProperties["storeFile"] ? file(keyProperties["storeFile"]) : null
+            storePassword keyProperties["storePassword"]
+        }
+    }
+
     defaultConfig {
         applicationId "com.locatemeup.locatemeup"
         minSdkVersion 21
@@ -45,7 +62,7 @@ android {
 
     buildTypes {
         release {
-            signingConfig signingConfigs.debug
+            signingConfig signingConfigs.release
             minifyEnabled false
             shrinkResources false
         }


### PR DESCRIPTION
- build.gradle: loads key.properties and wires release signingConfig
- android/.gitignore: excludes key.properties, *.jks, *.keystore
- .gitignore: excludes upload-keystore.jks and common Flutter build artefacts

key.properties itself is NOT committed (secret).

https://claude.ai/code/session_01PDCaeWBXCJdsf8UqBRzEoa