### PR TITLE
Disable native debug symbol stripping in release build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -65,6 +65,9 @@ android {
             signingConfig signingConfigs.release
             minifyEnabled false
             shrinkResources false
+            ndk {
+                debugSymbolLevel "NONE"
+            }
         }
     }
 }


### PR DESCRIPTION
Workaround for missing cmdline-tools (llvm-strip unavailable). debugSymbolLevel NONE tells AGP to skip the strip step entirely. Remove once cmdline-tools is installed via Android Studio SDK Manager.

https://claude.ai/code/session_01PDCaeWBXCJdsf8UqBRzEoa