### PR TITLE
Add packagingOptions.doNotStrip to suppress release strip failure

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -70,6 +70,10 @@ android {
             }
         }
     }
+
+    packagingOptions {
+        doNotStrip "**/*.so"
+    }
 }
 
 flutter {


### PR DESCRIPTION
debugSymbolLevel NONE prevents symbol generation; doNotStrip "**/*.so" suppresses the packaging-time strip step that also calls llvm-strip. Both are needed when cmdline-tools / NDK is not fully set up.

https://claude.ai/code/session_01PDCaeWBXCJdsf8UqBRzEoa