### PR TITLE
Fix Kotlin version mismatch: force 2.1.0 stdlib, skip metadata versio…

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -36,6 +36,7 @@ android {
 
     kotlinOptions {
         jvmTarget = "11"
+        freeCompilerArgs += ["-Xskip-metadata-version-check"]
     }
 
     sourceSets {
@@ -82,6 +83,6 @@ flutter {
 
 dependencies {
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.4"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:2.3.10"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7"
     implementation "androidx.multidex:multidex:2.0.1"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,6 +3,13 @@ allprojects {
         google()
         mavenCentral()
     }
+    configurations.all {
+        resolutionStrategy.eachDependency { details ->
+            if (details.requested.group == "org.jetbrains.kotlin") {
+                details.useVersion "2.1.0"
+            }
+        }
+    }
 }
 
 rootProject.buildDir = "../build"


### PR DESCRIPTION
…n check

Flutter's composite Gradle build overrides KGP to 2.1.0, but webview_flutter_android and the pinned stdlib were compiled at 2.3.x, causing incompatible metadata errors. Forces all org.jetbrains.kotlin library deps to 2.1.0 to match the effective compiler, and adds -Xskip-metadata-version-check to suppress errors from precompiled 2.3.x artifacts.

https://claude.ai/code/session_01PDCaeWBXCJdsf8UqBRzEoa