### PR TITLE
Fix Kotlin metadata mismatch: apply skip-version-check to all subproj…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,11 +3,12 @@ allprojects {
         google()
         mavenCentral()
     }
-    configurations.all {
-        resolutionStrategy.eachDependency { details ->
-            if (details.requested.group == "org.jetbrains.kotlin") {
-                details.useVersion "2.1.0"
-            }
+}
+
+subprojects {
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+        kotlinOptions {
+            freeCompilerArgs += ["-Xskip-metadata-version-check"]
         }
     }
 }


### PR DESCRIPTION
…ects

The broad resolutionStrategy forcing kotlin artifacts to 2.1.0 broke kotlin-build-tools-compat (introduced post-2.1.0). Replace with a targeted freeCompilerArgs override on all KotlinCompile tasks across subprojects so plugin modules like audioplayers_android also skip the metadata version check.

https://claude.ai/code/session_01PDCaeWBXCJdsf8UqBRzEoa