### PR TITLE
Fix Kotlin stdlib version: selectively pin stdlib to 2.1.0, fix freeC…

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -36,7 +36,7 @@ android {
 
     kotlinOptions {
         jvmTarget = "11"
-        freeCompilerArgs += ["-Xskip-metadata-version-check"]
+        freeCompilerArgs = freeCompilerArgs + ["-Xskip-metadata-version-check"]
     }
 
     sourceSets {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,12 +3,18 @@ allprojects {
         google()
         mavenCentral()
     }
-}
-
-subprojects {
-    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-        kotlinOptions {
-            freeCompilerArgs += ["-Xskip-metadata-version-check"]
+    configurations.all {
+        resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+            if (details.requested.group == "org.jetbrains.kotlin") {
+                def name = details.requested.name
+                if (name == "kotlin-stdlib" ||
+                        name == "kotlin-stdlib-jdk7" ||
+                        name == "kotlin-stdlib-jdk8" ||
+                        name == "kotlin-stdlib-common") {
+                    details.useVersion "2.1.0"
+                    details.because "Pin stdlib to match Flutter SDK's effective Kotlin compiler 2.1.0"
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
…ompilerArgs syntax

Flutter SDK's effective Kotlin compiler is 2.1.0 but transitive deps pull in kotlin-stdlib 2.3.10, causing binary metadata version errors. Pin only the stdlib artifacts (not build-tools) to 2.1.0 to avoid breaking kotlin-build-tools-compat. Also fix freeCompilerArgs assignment syntax in Groovy DSL.

https://claude.ai/code/session_01PDCaeWBXCJdsf8UqBRzEoa