### PR TITLE
Derive ndkPath from local.properties, use AGP 8.x packaging DSL

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -28,6 +28,15 @@ android {
     compileSdk 36
     ndkVersion "28.2.13676358"
 
+    // Resolve NDK path: ndk.dir > sdk.dir/ndk/<version> (local.properties)
+    def _ndkDir = localProperties.getProperty("ndk.dir")
+    def _sdkDir = localProperties.getProperty("sdk.dir")
+    if (_ndkDir) {
+        ndkPath _ndkDir
+    } else if (_sdkDir) {
+        ndkPath "${_sdkDir}/ndk/28.2.13676358"
+    }
+
     compileOptions {
         coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_11
@@ -72,8 +81,10 @@ android {
         }
     }
 
-    packagingOptions {
-        doNotStrip "**/*.so"
+    packaging {
+        jniLibs {
+            keepDebugSymbols += ["**/*.so"]
+        }
     }
 }
 


### PR DESCRIPTION
AGP was unable to locate the NDK despite ndkVersion being set, because neither ndk.dir nor sdk.dir paths were being resolved at build time. Explicitly construct ndkPath from local.properties sdk.dir + ndk version. Also replace deprecated packagingOptions.doNotStrip with the AGP 8.x packaging.jniLibs.keepDebugSymbols API.

https://claude.ai/code/session_01PDCaeWBXCJdsf8UqBRzEoa