### PR TITLE
Remove ndkPath from build.gradle — ndk.dir in local.properties is suf…

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -28,15 +28,6 @@ android {
     compileSdk 36
     ndkVersion "28.2.13676358"
 
-    // Resolve NDK path: ndk.dir > sdk.dir/ndk/<version> (local.properties)
-    def _ndkDir = localProperties.getProperty("ndk.dir")
-    def _sdkDir = localProperties.getProperty("sdk.dir")
-    if (_ndkDir) {
-        ndkPath _ndkDir
-    } else if (_sdkDir) {
-        ndkPath "${_sdkDir}/ndk/28.2.13676358"
-    }
-
     compileOptions {
         coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_11


### PR DESCRIPTION
…ficient

AGP rejects having both android.ndkPath and ndk.dir set simultaneously. ndk.dir in local.properties covers both Gradle and Flutter CLI NDK discovery.

https://claude.ai/code/session_01PDCaeWBXCJdsf8UqBRzEoa