### PR TITLE
Remove audioplayers dependency — no longer used after iOS ringtone re…

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   geolocator: ^12.0.0
   google_maps_flutter: ^2.6.1
   flutter_local_notifications: ^17.2.1
-  audioplayers: ^6.1.0
+
   shared_preferences: ^2.3.2
   google_mobile_ads: ^5.1.0
   in_app_review: ^2.0.9


### PR DESCRIPTION
…moval

audioplayers_darwin was still being registered on iOS despite having no call sites, causing 'Module not found' build errors in Xcode.

https://claude.ai/code/session_01PDCaeWBXCJdsf8UqBRzEoa